### PR TITLE
Prevent taskbar icon for the notification window

### DIFF
--- a/src/nw-desktop-notifications.js
+++ b/src/nw-desktop-notifications.js
@@ -27,6 +27,7 @@
 			show: false,
 			resizable: true
 		});
+		win.setShowInTaskbar(false);
 		window.DEA.DesktopNotificationsWindow = win;
 		window.DEA.DesktopNotificationsWindowIsLoaded = false;
 		win.on('loaded', function(){


### PR DESCRIPTION
I found it really useful when developing tray apps when icon is not desired.
